### PR TITLE
Support building of Pixhawk firmware under Vagrant/VirtualBox.

### DIFF
--- a/Tools/vagrant/initvagrant.sh
+++ b/Tools/vagrant/initvagrant.sh
@@ -1,12 +1,49 @@
 #!/bin/bash
 
-set -e 
+set -e
 
 echo "Initial setup of SITL-vagrant instance."
-sudo apt-get -y update
-sudo apt-get -y install dos2unix python-wxgtk2.8 python-scipy python-matplotlib python-opencv python-pip g++ g++-4.7 gawk git ccache  python-serial python-wxgtk2.8 python-lxml screen
 
-sudo pip install pymavlink MAVProxy
+BASE_PKGS="gawk make git arduino-core curl"
+SITL_PKGS="g++ python-pip python-matplotlib python-serial python-wxgtk2.8 python-scipy python-opencv python-numpy python-empy python-pyparsing ccache"
+AVR_PKGS="gcc-avr binutils-avr avr-libc"
+PYTHON_PKGS="pymavlink MAVProxy droneapi"
+PX4_PKGS="python-serial python-argparse openocd flex bison libncurses5-dev \
+          autoconf texinfo build-essential libftdi-dev libtool zlib1g-dev \
+          zip genromfs"
+UBUNTU64_PKGS="libc6:i386 libgcc1:i386 gcc-4.6-base:i386 libstdc++5:i386 libstdc++6:i386"
+
+# GNU Tools for ARM Embedded Processors
+# (see https://launchpad.net/gcc-arm-embedded/)
+ARM_ROOT="gcc-arm-none-eabi-4_7-2014q2"
+ARM_TARBALL="$ARM_ROOT-20140408-linux.tar.bz2"
+ARM_TARBALL_URL="http://firmware.diydrones.com/Tools/PX4-tools/$ARM_TARBALL"
+
+# Ardupilot Tools
+ARDUPILOT_TOOLS="ardupilot/Tools/autotest"
+
+sudo usermod -a -G dialout $USER
+
+sudo apt-get -y remove modemmanager
+sudo apt-get -y update
+sudo apt-get -y install dos2unix g++-4.7 ccache python-lxml screen
+sudo apt-get -y install $BASE_PKGS $SITL_PKGS $PX4_PKGS $UBUNTU64_PKGS $AVR_PKGS
+sudo pip -q install $PYTHON_PKGS
+sudo pip install catkin_pkg
+
+
+# ARM toolchain
+if [ ! -d /opt/$ARM_ROOT ]; then
+    (
+        cd /opt;
+        sudo wget -nv $ARM_TARBALL_URL;
+        sudo tar xjf ${ARM_TARBALL};
+        sudo rm ${ARM_TARBALL};
+    )
+fi
+
+exportline="export PATH=/opt/$ARM_ROOT/bin:\$PATH"
+if grep -Fxq "$exportline" /home/vagrant/.profile; then echo nothing to do ; else echo $exportline >> /home/vagrant/.profile; fi
 
 echo "source /vagrant/Tools/vagrant/shellinit.sh" >>/home/vagrant/.profile
 ln -fs /vagrant/Tools/vagrant/screenrc /home/vagrant/.screenrc

--- a/Tools/vagrant/shellinit.sh
+++ b/Tools/vagrant/shellinit.sh
@@ -7,5 +7,3 @@ cd $APMROOT/ArduCopter
 
 echo "Ardupilot environment ready.  Run 'sim_vehicle.sh' to start simulating an arducopter instance."
 echo "or run 'make sitl' to just do a test build."
-echo "NOTE: This vagrant build environment isn't currently intended for building PX4 loads, but if someone wants"
-echo "to add that ability it wouldn't be too difficult."

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,9 +9,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/trusty32"
   # push.app = "geeksville/ardupilot-sitl"
 
-  # Allow symlinks - I think this is no longer needed
-  # config.vm.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/cross-compiler", "1"]
-
   # The following forwarding is not necessary (or possible), because our sim_vehicle.sh is smart enough to send packets
   # out to the containing OS
   # config.vm.network "forwarded_port", guest: 14550, host: 14550, protocol: "udp"
@@ -28,7 +25,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.customize ["modifyvm", :id, "--memory", "2048"]
       vb.customize ["modifyvm", :id, "--ioapic", "on"]
       vb.customize ["modifyvm", :id, "--cpus", "2"]
+      # NuttX needs symlinks. If you want to go that route you need this setting, but rsync is easier. 
+#      vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/PX4NuttX", "1"]
+      # Make some effort to avoid clock skew
+      vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", "5000"]
+      vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-start"]
+      vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-on-restore", "1"]
   end
+
+  config.vm.synced_folder "../PX4Firmware", "/PX4Firmware"
+  config.vm.synced_folder "../PX4NuttX", "/PX4NuttX", type: "rsync"
+  config.vm.synced_folder "../uavcan", "/uavcan"
 
   config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"  
 end


### PR DESCRIPTION
On my Windows 7 machine this is at least 5x faster than a mingw based
build. Most of the requirements were taken from install-prereqs-ubuntu.sh
