### PR TITLE
AP_CRSF_Telem.cpp: fix GPS alt message

### DIFF
--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -367,7 +367,7 @@ void AP_CRSF_Telem::calc_gps()
     _telem.bcast.gps.latitude = htobe32(loc.lat);
     _telem.bcast.gps.longitude = htobe32(loc.lng);
     _telem.bcast.gps.groundspeed = htobe16(roundf(AP::gps().ground_speed() * 100000 / 3600));
-    _telem.bcast.gps.altitude = htobe16(loc.alt + 1000);
+    _telem.bcast.gps.altitude = htobe16(constrain_int16(loc.alt / 100, 0, 5000) + 1000);
     _telem.bcast.gps.gps_heading = htobe16(roundf(AP::gps().ground_course() * 100.0f));
     _telem.bcast.gps.satellites = AP::gps().num_sats();
 


### PR DESCRIPTION
expects alt in m + 1000,  0 - 5000 m. reference crsf manual / bf handling. tested working.