### PR TITLE
Copter: add VALT velocity alt-hold flight mode

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -227,6 +227,7 @@ public:
     friend class ModeZigZag;
     friend class ModeAutorotate;
     friend class ModeTurtle;
+    friend class ModeVelAltHold;
 
     friend class _AutoTakeoff;
 
@@ -1099,6 +1100,9 @@ private:
 #endif
 #if MODE_TURTLE_ENABLED
     ModeTurtle mode_turtle;
+#endif
+#if MODE_VALT_ENABLED
+    ModeVelAltHold mode_valt;
 #endif
 
     // mode.cpp

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -239,6 +239,12 @@
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
+// VALT - velocity-controlled alt hold
+#ifndef MODE_VALT_ENABLED
+# define MODE_VALT_ENABLED 1
+#endif
+
+//////////////////////////////////////////////////////////////////////////////
 // Flowhold - use optical flow to hover in place
 #ifndef MODE_FLOWHOLD_ENABLED
 # define MODE_FLOWHOLD_ENABLED AP_OPTICALFLOW_ENABLED

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -152,6 +152,11 @@ Mode *Copter::mode_from_mode_num(const Mode::Number mode)
             return &mode_turtle;
 #endif
 
+#if MODE_VALT_ENABLED
+        case Mode::Number::VALT:
+            return &mode_valt;
+#endif
+
         default:
             break;
     }
@@ -208,7 +213,8 @@ bool Copter::gcs_mode_enabled(const Mode::Number mode_num)
         (uint8_t)Mode::Number::SYSTEMID,
         (uint8_t)Mode::Number::AUTOROTATE,
         (uint8_t)Mode::Number::AUTO_RTL,
-        (uint8_t)Mode::Number::TURTLE
+        (uint8_t)Mode::Number::TURTLE,
+        (uint8_t)Mode::Number::VALT
     };
 
     if (!block_GCS_mode_change((uint8_t)mode_num, mode_list, ARRAY_SIZE(mode_list))) {

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -101,6 +101,7 @@ public:
         AUTOROTATE =   26,  // Autonomous autorotation
         AUTO_RTL =     27,  // Auto RTL, this is not a true mode, AUTO will report as this mode if entered to perform a DO_LAND_START Landing sequence
         TURTLE =       28,  // Flip over after crash
+        VALT =         29,  // Velocity-controlled alt hold
 
         // Mode number 30 reserved for "offboard" for external/lua control.
 
@@ -521,7 +522,9 @@ protected:
     const char *name() const override { return "Altitude Hold"; }
     const char *name4() const override { return "ALTH"; }
 
-private:
+    // handle the Flying state inside run(); virtual so ModeVelAltHold
+    // can override just this piece
+    virtual void alt_hold_run_flying(float &target_roll_rad, float &target_pitch_rad, float target_climb_rate_ms);
 
 };
 
@@ -1918,6 +1921,26 @@ private:
     // Semaphore to protect the motors from the arming state
     HAL_Semaphore msem;
     bool shutdown;
+};
+#endif
+
+#if MODE_VALT_ENABLED
+class ModeVelAltHold : public ModeAltHold {
+
+public:
+    // inherit constructor
+    using ModeAltHold::Mode;
+    Number mode_number() const override { return Number::VALT; }
+
+protected:
+
+    const char *name() const override { return "VALT Hold"; }
+    const char *name4() const override { return "VALT"; }
+
+    // velocity-controlled Flying state: no surface tracking,
+    // pos_desired override for velocity control
+    void alt_hold_run_flying(float &target_roll_rad, float &target_pitch_rad, float target_climb_rate_ms) override;
+
 };
 #endif
 

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -78,22 +78,7 @@ void ModeAltHold::run()
 
     case AltHoldModeState::Flying:
         motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
-
-#if AP_AVOIDANCE_ENABLED
-        // apply avoidance
-        copter.avoid.adjust_roll_pitch_rad(target_roll_rad, target_pitch_rad, attitude_control->lean_angle_max_rad());
-#endif
-
-        // get avoidance adjusted climb rate
-        target_climb_rate_ms = get_avoidance_adjusted_climbrate_ms(target_climb_rate_ms);
-
-#if AP_RANGEFINDER_ENABLED
-        // update the vertical offset based on the surface measurement
-        copter.surface_tracking.update_surface_offset();
-#endif
-
-        // Send the commanded climb rate to the position controller
-        pos_control->D_set_pos_target_from_climb_rate_ms(target_climb_rate_ms);
+        alt_hold_run_flying(target_roll_rad, target_pitch_rad, target_climb_rate_ms);
         break;
     }
 
@@ -102,4 +87,25 @@ void ModeAltHold::run()
 
     // run the vertical position controller and set output throttle
     pos_control->D_update_controller();
+}
+
+// alt_hold_run_flying - handle the Flying state; virtual so subclasses
+// (ModeVelAltHold) can replace just this piece
+void ModeAltHold::alt_hold_run_flying(float &target_roll_rad, float &target_pitch_rad, float target_climb_rate_ms)
+{
+#if AP_AVOIDANCE_ENABLED
+    // apply avoidance
+    copter.avoid.adjust_roll_pitch_rad(target_roll_rad, target_pitch_rad, attitude_control->lean_angle_max_rad());
+#endif
+
+    // get avoidance adjusted climb rate
+    target_climb_rate_ms = get_avoidance_adjusted_climbrate_ms(target_climb_rate_ms);
+
+#if AP_RANGEFINDER_ENABLED
+    // update the vertical offset based on the surface measurement
+    copter.surface_tracking.update_surface_offset();
+#endif
+
+    // Send the commanded climb rate to the position controller
+    pos_control->D_set_pos_target_from_climb_rate_ms(target_climb_rate_ms);
 }

--- a/ArduCopter/mode_valt.cpp
+++ b/ArduCopter/mode_valt.cpp
@@ -1,0 +1,35 @@
+#include "Copter.h"
+
+#if MODE_VALT_ENABLED
+
+/*
+ * VALT (velocity alt hold) flight mode.
+ *
+ * Inherits from AltHold, overriding only the Flying state.  Surface
+ * tracking is skipped so its offsets do not fight pilot stick input,
+ * and pos_desired is overridden with the current position when the
+ * stick is off-centre so the position P loop is bypassed.  When the
+ * stick returns to centre pos_desired freezes and position P gently
+ * holds height.
+ */
+
+// velocity-controlled Flying state
+void ModeVelAltHold::alt_hold_run_flying(float &target_roll_rad, float &target_pitch_rad, float target_climb_rate_ms)
+{
+    // get avoidance adjusted climb rate
+    target_climb_rate_ms = get_avoidance_adjusted_climbrate_ms(target_climb_rate_ms);
+
+    // Send the commanded climb rate to the position controller
+    pos_control->D_set_pos_target_from_climb_rate_ms(target_climb_rate_ms);
+
+    // Override pos_desired with the current position so the position P
+    // loop does not fight the pilot's stick input.  When the stick
+    // returns to centre (zero climb rate), stop overriding so that
+    // pos_desired freezes at the current altitude and position P gently
+    // holds height.
+    if (!is_zero(target_climb_rate_ms)) {
+        pos_control->set_pos_desired_U_m(pos_control->get_pos_estimate_U_m());
+    }
+}
+
+#endif  // MODE_VALT_ENABLED

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -279,6 +279,53 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
         self.do_RTL()
 
+    def ModeVAltHold(self):
+        '''Test VALT velocity alt-hold mode (mode 29)'''
+        # use mode number directly since pymavlink does not know VALT
+        VALT = 29
+
+        self.takeoff(10, mode="ALT_HOLD")
+        self.change_mode(VALT)
+
+        # verify altitude is maintained with neutral sticks
+        self.progress("Checking altitude hold with velocity control")
+        self.watch_altitude_maintained(altitude_min=9, altitude_max=11)
+
+        # verify altitude is maintained while flying laterally
+        self.progress("Checking altitude hold during lateral flight")
+        self.set_rc_from_map({
+            1: 1000,
+            2: 1000,
+        })
+        self.watch_altitude_maintained(altitude_min=9, altitude_max=11)
+        self.set_rc_from_map({
+            1: 1500,
+            2: 1500,
+        })
+
+        # command a climb and verify altitude increases
+        self.progress("Commanding climb with throttle 1800")
+        self.set_rc(3, 1800)
+        self.wait_altitude(12, 25, relative=True, timeout=10)
+        alt_after_climb = self.get_altitude(relative=True)
+        self.progress("Altitude after climb: %.1f" % alt_after_climb)
+
+        # release stick to neutral and let it settle
+        self.progress("Releasing stick, checking altitude settles")
+        self.set_rc(3, 1500)
+        self.delay_sim_time(3)
+        settled_alt = self.get_altitude(relative=True)
+        self.progress("Settled altitude: %.1f" % settled_alt)
+
+        # verify altitude is maintained at the new altitude
+        self.watch_altitude_maintained(
+            altitude_min=settled_alt - 1,
+            altitude_max=settled_alt + 1,
+            minimum_duration=3,
+        )
+
+        self.do_RTL()
+
     def fly_to_origin(self, final_alt=10):
         origin = self.poll_message("GPS_GLOBAL_ORIGIN")
         self.change_mode("GUIDED")
@@ -12957,6 +13004,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.GPSGlitchLoiter2,
              self.GPSGlitchAuto,
              self.ModeAltHold,
+             self.ModeVAltHold,
              self.ModeLoiter,
              self.SimpleMode,
              self.SuperSimpleCircle,

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -189,6 +189,7 @@ BUILD_OPTIONS = [
     Feature('Copter', 'MODE_SPORT', 'MODE_SPORT_ENABLED', 'Enable Mode Sport', 0, None),
     Feature('Copter', 'MODE_FOLLOW', 'MODE_FOLLOW_ENABLED', 'Enable Mode Follow', 0, 'AC_AVOID,AP_FOLLOW'),
     Feature('Copter', 'MODE_TURTLE', 'MODE_TURTLE_ENABLED', 'Enable Mode Turtle', 0, None),
+    Feature('Copter', 'MODE_VALT', 'MODE_VALT_ENABLED', 'Enable Mode VALT', 0, None),
     Feature('Copter', 'MODE_GUIDED_NOGPS', 'MODE_GUIDED_NOGPS_ENABLED', 'Enable Mode Guided NoGPS', 0, None),
     Feature('Copter', 'MODE_FLOWHOLD', 'MODE_FLOWHOLD_ENABLED', 'Enable Mode Flowhold', 0, "OPTICALFLOW"),
     Feature('Copter', 'MODE_FLIP', 'MODE_FLIP_ENABLED', 'Enable Mode Flip', 0, None),

--- a/libraries/AP_OSD/AP_OSD_ParamSetting.cpp
+++ b/libraries/AP_OSD/AP_OSD_ParamSetting.cpp
@@ -227,7 +227,7 @@ static const char* FLTMODES[] = {
     "STAB", "ACRO", "ALTHOLD", "AUTO", "GUIDED", "LOIT", "RTL", "CIRC", "", "LAND",
     "", "DRFT", "", "SPORT", "FLIP", "ATUN", "POSHLD", "BRAKE", "THROW", "AVD_ADSB",
     "GUID_NOGPS", "SMRTRTL", "FLOHOLD", "FOLLOW", "ZIGZAG", "SYSID", "HELI_ARO", "AUTORTL",
-    "TRTLE"
+    "TRTLE", "VALT"
 };
 
 static const char* FS_OPTIONS[] = {
@@ -248,7 +248,7 @@ const AP_OSD_ParamSetting::ParamMetadata AP_OSD_ParamSetting::_param_metadata[un
     { -1, AP_SerialManager::SerialProtocol_NumProtocols - 1,    1, ARRAY_SIZE(SERIAL_PROTOCOL_VALUES), SERIAL_PROTOCOL_VALUES },  // OSD_PARAM_SERIAL_PROTOCOL
     { 0, SRV_Channel::k_nr_aux_servo_functions - 1,             1, ARRAY_SIZE(SERVO_FUNCTIONS), SERVO_FUNCTIONS },                // OSD_PARAM_SERVO_FUNCTION
     { 0, 105, 1, ARRAY_SIZE(AUX_OPTIONS), AUX_OPTIONS },                        // OSD_PARAM_AUX_FUNCTION
-    { 0, 28, 1,  ARRAY_SIZE(FLTMODES), FLTMODES },                              // OSD_PARAM_FLIGHT_MODE
+    { 0, 29, 1,  ARRAY_SIZE(FLTMODES), FLTMODES },                              // OSD_PARAM_FLIGHT_MODE
     { 0, 3, 1,   ARRAY_SIZE(FS_OPTIONS), FS_OPTIONS },                          // OSD_PARAM_FAILSAFE_ACTION
     { 0, 5, 1,   ARRAY_SIZE(FS_ACT), FS_ACT },                                  // OSD_PARAM_FAILSAFE_ACTION_1
     { 0, 5, 1,   ARRAY_SIZE(THR_FS_ACT), THR_FS_ACT },                          // OSD_PARAM_FAILSAFE_ACTION_2


### PR DESCRIPTION
## Summary

- Add VALT (Velocity Alt Hold) as flight mode number 29 — pilot stick commands climb/descent **rate** rather than driving a jerk-limited position trajectory
- VALT inherits from AltHold via a virtual `alt_hold_run_flying()` method, overriding only the Flying state: surface tracking is skipped so its offsets don't fight pilot stick input, and `pos_desired` is set to the current position when the stick is off-centre so the position-P loop is bypassed
- When the stick returns to centre, `pos_desired` freezes at the current altitude and the position-P loop gently holds height
- Includes OSD display support, build option (`MODE_VALT_ENABLED`), and autotest

### Why a separate mode instead of an AltHold option?

Velocity alt-hold is inherently more robust to barometric pressure corruption from prop wash — during stick input `pos_desired = pos_actual`, so any baro offset accumulated during the manoeuvre cancels out. When the stick returns to centre there is zero initial position error by construction. This makes it particularly well suited for small high-disc-loading copters with significant baro ground effect, where standard AltHold's jerk-limited trajectory can diverge from the corrupted EKF estimate.

The behavioural difference is significant enough to warrant a distinct mode rather than a runtime option within AltHold.

## Test plan

- [x] SITL build passes (`./waf copter`)
- [ ] Run `Tools/autotest/autotest.py build.Copter test.Copter.ModeVAltHold`
- [ ] Verify altitude hold with neutral sticks
- [ ] Verify altitude hold during lateral flight
- [ ] Verify climb/descent responds to throttle stick
- [ ] Verify altitude freezes when stick returns to centre
- [ ] Test on hardware with baro prop wash effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)